### PR TITLE
PDT-250 Redis circuit breaker

### DIFF
--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -22,7 +22,7 @@ if settings.CACHEOPS_DEGRADE_ON_FAILURE:
     def handle_connection_failure(call):
         """Skip Redis calls for a configurable period after a timeout."""
         global circuit_breaker_opened
-        if circuit_breaker_opened:
+        if settings.FEATURE_CACHEOPS_CIRCUIT_BREAKER and circuit_breaker_opened:
             # Circuit breaker is open! Should we close it yet?
             if time() - circuit_breaker_opened > settings.REDIS_CIRCUIT_BREAKER_RESET_SECONDS:
                 # Yes, let's close the circuit breaker


### PR DESCRIPTION
This change adds a "circuit breaker" that will prevent cacheops from trying to call Redis for a configurable period after a connection or call to Redis has failed. During that period, all cache `get`s will miss and presumably hit the database.