### PR TITLE
PDT-366 Use mmapped file for Redis circuit breaker

### DIFF
--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -39,9 +39,9 @@ if settings.CACHEOPS_DEGRADE_ON_FAILURE:
                 logger.info("Closing Redis circuit breaker")
                 circuit_breaker.value = 0
             else:
-                # No, just skip this Redis call
+                # No, just skip this Redis call and emulate a cache miss
                 logger.debug("Redis circuit breaker is open! Skipping Redis call")
-                return
+                return None
         try:
             return call()
         except redis.RedisError as e:

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -46,8 +46,7 @@ if settings.CACHEOPS_DEGRADE_ON_FAILURE:
             return call()
         except redis.RedisError as e:
             # Redis timed out! Let's open the circuit breaker
-            logger.warn("The cacheops cache is unreachable! Error: %s" % e)
-            logger.info("Opening Redis circuit breaker")
+            logger.warn("The cache is unreachable! Opening Redis circuit breaker. Error: %s", e)
             circuit_breaker.value = int(time())
         except Exception as e:
             logger.warn(e)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = open('README.rst').read()    \
 
 setup(
     name='django-cacheops',
-    version='3.0.1.2',
+    version='3.0.1.3',
     author='Hearst Digital Media',
     author_email='nwolff@hearst.com',
 


### PR DESCRIPTION
This changes the cacheops circuit breaker to share its "circuit breaker is open" flag with the one used by the core Django cache's circuit breaker as implemented in https://github.com/HearstCorp/rover/pull/909.