### PR TITLE
PDT-570 Combine Redis circuit breakers

### DIFF
--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -1,46 +1,28 @@
 from __future__ import absolute_import
 import warnings
 import six
-from time import time
-import logging
+import sys
+import traceback
 
 from funcy import decorator, identity, memoize
 import redis
+from django.core.exceptions import ImproperlyConfigured
 import random
 
 from .conf import settings
 
-logger = logging.getLogger(__name__)
-
-# Global circuit-breaker flag. Values:
-#   None = circuit breaker closed, Redis calls are attempted.
-#   <time_seconds> = circuit breaker open, Redis calls are skipped.
-circuit_breaker_opened = None
 
 if settings.CACHEOPS_DEGRADE_ON_FAILURE:
     @decorator
     def handle_connection_failure(call):
-        """Skip Redis calls for a configurable period after a timeout."""
-        global circuit_breaker_opened
-        if settings.FEATURE_CACHEOPS_CIRCUIT_BREAKER and circuit_breaker_opened:
-            # Circuit breaker is open! Should we close it yet?
-            if time() - circuit_breaker_opened > settings.REDIS_CIRCUIT_BREAKER_RESET_SECONDS:
-                # Yes, let's close the circuit breaker
-                logger.info("Closing Redis circuit breaker")
-                circuit_breaker_opened = None
-            else:
-                # No, just skip this Redis call
-                logger.debug("Redis circuit breaker is open! Skipping Redis call")
-                return
         try:
             return call()
-        except redis.RedisError as e:
-            # Redis timed out! Let's open the circuit breaker
-            logger.warn("The cacheops cache is unreachable! Error: %s" % e)
-            logger.info("Opening Redis circuit breaker")
-            circuit_breaker_opened = time()
+        except redis.ConnectionError as e:
+            warnings.warn("The cacheops cache is unreachable! Error: %s" % e, RuntimeWarning)
+        except redis.TimeoutError as e:
+            warnings.warn("The cacheops cache timed out! Error: %s" % e, RuntimeWarning)
         except Exception as e:
-            logger.warn(e)
+            warnings.warn("".join(traceback.format_exception(*sys.exc_info())))
 else:
     handle_connection_failure = identity
 

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -27,10 +27,9 @@ if settings.CACHEOPS_DEGRADE_ON_FAILURE:
 else:
     handle_connection_failure = identity
 
-client_class = redis.StrictRedis
-custom_client_class = getattr(settings, 'CACHEOPS_CLIENT_CLASS', None)
-if custom_client_class:
-    client_class = import_string(custom_client_class)
+client_class_name = getattr(settings, 'CACHEOPS_CLIENT_CLASS', None)
+client_class = import_string(client_class_name) if client_class_name else redis.StrictRedis
+
 
 class SafeRedis(client_class):
     get = handle_connection_failure(redis.StrictRedis.get)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = open('README.rst').read()    \
 
 setup(
     name='django-cacheops',
-    version='3.0.1.2',
+    version='3.0.1.4',
     author='Hearst Digital Media',
     author_email='nwolff@hearst.com',
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = open('README.rst').read()    \
 
 setup(
     name='django-cacheops',
-    version='3.0.1.3',
+    version='3.0.1.2',
     author='Hearst Digital Media',
     author_email='nwolff@hearst.com',
 


### PR DESCRIPTION
This would let us pass the new `StrictRedis` subclass into cacheops so we can use it for the circuit breaker instead of maintaining all that code in both repos.

It may be easier to CR this by commit – https://github.com/HearstCorp/django-cacheops/pull/7/commits/3919d50021582941d38edd3cc315851f971129ae is the important one – since it reverts the duplicate code.