### PR TITLE
PDT-618 Don't read from primary

### DIFF
--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -62,6 +62,7 @@ class SafeRedis(client_class):
                 raise
             connection = self.connection_pool.get_connection(args[0], **options)
             connection.disconnect()
+            set_redis_replicas()
             warnings.warn("Primary probably failed over, reconnecting")
             return super(SafeRedis, self).execute_command(*args, **options)
 


### PR DESCRIPTION
We don't want to read from the Redis primary, and when AWS ElastiCache promotes a Redis replica to primary, we want to stop reading from it and start reading from its replacement.

This change attempts to identify the primary by comparing the IP address we get by resolving its hostname alias to the IPs of the replicas. On failover, we assume that the DNS cache is clear and we can find the new primary the same way immediately.

This is hard to test in Docker since even if you set up a Redis cluster you don't have the DNS alias switching. I plan to deploy it to one of the EC2 environments for testing.