### PR TITLE
PDT-618 Weighted replica round robin

### DIFF
--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -34,7 +34,11 @@ redis_replicas = []
 
 
 def ip(url):
-    return socket.gethostbyname(urlparse(url).hostname)
+    try:
+        return socket.gethostbyname(urlparse(url).hostname)
+    except socket.gaierror:
+        warnings.warn('Hostname in URL %s did not resolve' % url)
+        raise
 
 
 def set_redis_replicas():

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -46,12 +46,12 @@ def set_redis_replicas():
         temp = settings.REDIS_REPLICAS.split(',')
     else:
         temp = list(settings.REDIS_REPLICAS)
-    master_url = settings.REDIS_MASTER
-    master_ip = ip(master_url)
-    temp = [r for r in temp if ip(r) != master_ip]
+    primary_url = settings.REDIS_MASTER
+    primary_ip = ip(primary_url)
+    temp = [r for r in temp if ip(r) != primary_ip]
     temp = map(redis.StrictRedis.from_url, temp)
     temp = [r for r in temp for _ in range(settings.REDIS_REPLICA_WEIGHT)]
-    temp.append(redis.StrictRedis.from_url(master_url))
+    temp.append(redis.StrictRedis.from_url(primary_url))
     redis_replicas = temp
 
 

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -49,8 +49,8 @@ def set_redis_replicas():
     master_url = settings.REDIS_MASTER
     master_ip = ip(master_url)
     temp = [r for r in temp if ip(r) != master_ip]
-    temp = [r for r in temp for _ in range(settings.REDIS_REPLICA_WEIGHT)]
     temp = map(redis.StrictRedis.from_url, temp)
+    temp = [r for r in temp for _ in range(settings.REDIS_REPLICA_WEIGHT)]
     temp.append(redis.StrictRedis.from_url(master_url))
     redis_replicas = temp
 

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -62,6 +62,7 @@ class SafeRedis(client_class):
                 raise
             connection = self.connection_pool.get_connection(args[0], **options)
             connection.disconnect()
+            set_redis_replicas()
             warnings.warn("Primary probably failed over, reconnecting")
             return super(SafeRedis, self).execute_command(*args, **options)
 


### PR DESCRIPTION
We don't want to read so much from the Redis primary, and when AWS ElastiCache promotes a Redis replica to primary, we want to read less from it and start reading more from its replacement.

(We still want to read _some_ from the primary, to trigger eviction of expired keys that will get replicated to the replicas – Redis 2.8 doesn't expire on replicas ಠ_ಠ)

This change attempts to identify the primary by comparing the IP address we get by resolving its hostname alias to the IPs of the replicas. On failover, we assume that the DNS cache is clear and we can find the new primary the same way immediately.

Then it stocks the list of Redis objects to read from with multiple pointers to each replica, so that more reads will go to the replicas.

This is hard to test in Docker since even if you set up a Redis cluster you don't have the DNS alias switching. We plan to deploy it to one of the EC2 environments for testing.