### PR TITLE
PDT-618 Redo redis.py

### DIFF
--- a/cacheops/__init__.py
+++ b/cacheops/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (3, 0, 1)
+VERSION = (3, 0, 1, 4)
 __version__ = '.'.join(map(str, VERSION if VERSION[-1] else VERSION[:2]))
 
 

--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -12,6 +12,8 @@ ALL_OPS = {'get', 'fetch', 'count', 'exists'}
 class Settings(object):
     CACHEOPS_ENABLED = True
     CACHEOPS_REDIS = {}
+    CACHEOPS_REDIS_REPLICAS = []
+    CACHEOPS_REPLICA_WEIGHT = 1
     CACHEOPS_DEFAULTS = {}
     CACHEOPS = {}
     CACHEOPS_LRU = False

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -71,8 +71,9 @@ if settings.CACHEOPS_REDIS_REPLICAS:
             if replica_weight > 1:
                 new_clients = [c for c in new_clients for _ in range(replica_weight)]
 
-            # Add just one Redis client for the primary
-            new_clients.append(read_client_class(**settings.CACHEOPS_REDIS))
+            # Add just one Redis client for the primary, if it was in the replicas
+            if len(new_clients) < len(replicas):
+                new_clients.append(read_client_class(**settings.CACHEOPS_REDIS))
 
             cls.read_clients = new_clients
 

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -1,20 +1,38 @@
 from __future__ import absolute_import
-import warnings
+
+import os.path
+import random
+import re
 import six
 import socket
 import sys
 import traceback
-from urlparse import urlparse
+import warnings
+from copy import copy
 
-from funcy import decorator, identity, memoize
 import redis
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
-import random
+from funcy import decorator, identity, memoize
 
 from .conf import settings
 
+handle_connection_failure = identity
+
+client_class_name = getattr(settings, 'CACHEOPS_CLIENT_CLASS', None)
+client_class = import_string(client_class_name) if client_class_name else redis.StrictRedis
+
+
+def ip(hostname):
+    try:
+        return socket.gethostbyname(hostname)
+    except socket.gaierror as err:
+        warnings.warn('Hostname %s did not resolve because %s' % (hostname, err))
+        raise
+
+
 if settings.CACHEOPS_DEGRADE_ON_FAILURE:
+
     @decorator
     def handle_connection_failure(call):
         try:
@@ -25,114 +43,74 @@ if settings.CACHEOPS_DEGRADE_ON_FAILURE:
             warnings.warn("The cacheops cache timed out! Error: %s" % e, RuntimeWarning)
         except Exception as e:
             warnings.warn("".join(traceback.format_exception(*sys.exc_info())))
-else:
-    handle_connection_failure = identity
 
-client_class_name = getattr(settings, 'CACHEOPS_CLIENT_CLASS', None)
-client_class = import_string(client_class_name) if client_class_name else redis.StrictRedis
-read_clients = []
+    class SafeRedis(client_class):
+        get = handle_connection_failure(client_class.get)
 
-
-def ip(url):
-    try:
-        return socket.gethostbyname(urlparse(url).hostname)
-    except socket.gaierror:
-        warnings.warn('Hostname in URL %s did not resolve' % url)
-        raise
+    client_class = SafeRedis
 
 
-def set_read_clients():
-    primary_url = settings.REDIS_MASTER
-    primary_ip = ip(primary_url)
-    replica_weight = settings.REDIS_REPLICA_WEIGHT
+if settings.CACHEOPS_REDIS_REPLICAS:
 
-    redis_urls = settings.REDIS_REPLICAS
-    # the conf could be a list or string
-    # list would look like: ["redis://cache-001:6379/1", "redis://cache-002:6379/2"]
-    # string would be: "redis://cache-001:6379/1,redis://cache-002:6379/2"
-    if isinstance(redis_urls, six.string_types):
-        redis_urls = redis_urls.split(',')
-    else:
-        redis_urls = list(redis_urls)
+    read_client_class = copy(client_class)
 
-    # Make Redis clients from all the URLs except the primary
-    new_read_clients = [redis.StrictRedis.from_url(u) for u in redis_urls if ip(u) != primary_ip]
+    class ReplicaProxyRedis(client_class):
 
-    # Duplicate each client a few times if desired
-    if replica_weight > 1:
-        new_read_clients = [c for c in new_read_clients for _ in range(replica_weight)]
+        read_clients = []
 
-    # Add just one Redis client for the primary
-    new_read_clients.append(redis.StrictRedis.from_url(primary_url))
+        @classmethod
+        def set_read_clients(cls):
+            primary_ip = ip(settings.CACHEOPS_REDIS['host'])
+            replicas = settings.CACHEOPS_REDIS_REPLICAS
+            replica_weight = settings.CACHEOPS_REPLICA_WEIGHT
 
-    global read_clients
-    read_clients = new_read_clients
+            # Make Redis clients from all the URLs except the primary
+            new_clients = [read_client_class(**r) for r in replicas if ip(r['host']) != primary_ip]
 
+            # Duplicate each client a few times if desired
+            if replica_weight > 1:
+                new_clients = [c for c in new_clients for _ in range(replica_weight)]
 
-class SafeRedis(client_class):
-    get = handle_connection_failure(redis.StrictRedis.get)
+            # Add just one Redis client for the primary
+            new_clients.append(read_client_class(**settings.CACHEOPS_REDIS))
 
-    def execute_command(self, *args, **options):
-        """ Handle failover of AWS elasticache."""
-        try:
-            return super(SafeRedis, self).execute_command(*args, **options)
-        except redis.ResponseError as e:
-            if "READONLY" not in e.message:
-                raise
-            connection = self.connection_pool.get_connection(args[0], **options)
-            connection.disconnect()
-            set_read_clients()
-            warnings.warn("Primary probably failed over, reconnecting")
-            return super(SafeRedis, self).execute_command(*args, **options)
+            cls.read_clients = new_clients
 
-
-class LazyRedis(object):
-    def _setup(self):
-        Redis = SafeRedis if settings.CACHEOPS_DEGRADE_ON_FAILURE else redis.StrictRedis
-
-        # Allow client connection settings to be specified by a URL.
-        if isinstance(settings.CACHEOPS_REDIS, six.string_types):
-            client = Redis.from_url(settings.CACHEOPS_REDIS)
-        else:
-            client = Redis(**settings.CACHEOPS_REDIS)
-
-        object.__setattr__(self, '__class__', client.__class__)
-        object.__setattr__(self, '__dict__', client.__dict__)
-
-    def __getattr__(self, name):
-        self._setup()
-        return getattr(self, name)
-
-    def __setattr__(self, name, value):
-        self._setup()
-        return setattr(self, name, value)
-
-CacheopsRedis = SafeRedis if settings.CACHEOPS_DEGRADE_ON_FAILURE else client_class
-try:
-    set_read_clients()
-except AttributeError as err:
-    redis_client = LazyRedis()
-else:
-    class ReplicaProxyRedis(CacheopsRedis):
-        """Proxy `get` calls to redis replica."""
         def get(self, *args, **kwargs):
+            """Proxy `get` calls to redis replica."""
+            if not self.read_clients:
+                self.set_read_clients()
             try:
-                client = random.choice(read_clients)
+                client = random.choice(self.read_clients)
                 return client.get(*args, **kwargs)
             except redis.ConnectionError:
                 return super(ReplicaProxyRedis, self).get(*args, **kwargs)
 
-    if isinstance(settings.CACHEOPS_REDIS, six.string_types):
-        redis_client = ReplicaProxyRedis.from_url(settings.CACHEOPS_REDIS)
-    else:
-        redis_client = ReplicaProxyRedis(**settings.CACHEOPS_REDIS)
+        def execute_command(self, *args, **options):
+            """Handle failover of AWS elasticache."""
+            try:
+                return super(ReplicaProxyRedis, self).execute_command(*args, **options)
+            except redis.ResponseError as e:
+                if "READONLY" not in e.message:
+                    raise
+                connection = self.connection_pool.get_connection(args[0], **options)
+                connection.disconnect()
+                self.read_clients = []
+                warnings.warn("Primary probably failed over, reconnecting")
+                return super(ReplicaProxyRedis, self).execute_command(*args, **options)
 
-### Lua script loader
+    client_class = ReplicaProxyRedis
 
-import re
-import os.path
+if isinstance(settings.CACHEOPS_REDIS, six.string_types):
+    redis_client = client_class.from_url(settings.CACHEOPS_REDIS)
+else:
+    redis_client = client_class(**settings.CACHEOPS_REDIS)
+
+
+# Lua script loader
 
 STRIP_RE = re.compile(r'TOSTRIP.*/TOSTRIP', re.S)
+
 
 @memoize
 def load_script(name, strip=False):


### PR DESCRIPTION
The previous merge of this branch failed the Docker build on Travis when it tries to look up the Redis primary's hostname – which doesn't exist there since we don't build the other containers.

Trying to fix that was made difficult by our repeated patches to the redis.py module which have made it very hard to maintain. This change simplifies the Redis client class construction, and makes the list of read replicas an attribute of that class instead of a global variable. It also cleans up the settings names.