### PR TITLE
PDT-628 Don't call cleanup fn if no conj keys were renamed

### DIFF
--- a/cacheops/__init__.py
+++ b/cacheops/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (3, 0, 1, 6)
+VERSION = (3, 0, 1, 7)
 __version__ = '.'.join(map(str, VERSION if VERSION[-1] else VERSION[:2]))
 
 

--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -48,7 +48,8 @@ if settings.FEATURE_FAST_INVALIDATION:
             '%08x' % random.randrange(16**8),
             json.dumps(obj_dict, default=str)
         ])
-        load_cleanup_fn()(renamed_keys)
+        if renamed_keys:
+            load_cleanup_fn()(renamed_keys)
 
     @memoize
     def load_cleanup_fn():

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = open('README.rst').read()    \
 
 setup(
     name='django-cacheops',
-    version='3.0.1.6',
+    version='3.0.1.7',
     author='Hearst Digital Media',
     author_email='nwolff@hearst.com',
 


### PR DESCRIPTION
Sometimes an invalidation call doesn't find any conj sets to delete! But the new cleanup function still gets called, and fails on `redis_client.delete([])`.

**This change skips calling the cleanup function if we didn't rename any conj keys.**