### PR TITLE
PDT-629 DNFs include TextField and IExact

### DIFF
--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -23,6 +23,7 @@ class Settings(object):
     CACHEOPS_CLEANUP_BATCH_SIZE = 1000
     FILE_CACHE_DIR = '/tmp/cacheops_file_cache'
     FILE_CACHE_TIMEOUT = 60*60*24*30
+    CACHEOPS_LONG_DISJUNCTION = 30
 
     def __getattribute__(self, name):
         if hasattr(base_settings, name):

--- a/cacheops/lua/fast_invalidate.lua
+++ b/cacheops/lua/fast_invalidate.lua
@@ -7,7 +7,7 @@ local obj = cjson.decode(ARGV[3])
 local conj_cache_key = function (db_table, scheme, obj)
     local parts = {}
     for field in string.gmatch(scheme, "[^,]+") do
-        table.insert(parts, field .. '=' .. tostring(obj[field]))
+        table.insert(parts, field .. '=' .. tostring(obj[field]):lower())
     end
 
     return 'conj:' .. db_table .. ':' .. table.concat(parts, '&')

--- a/cacheops/lua/fast_invalidate.lua
+++ b/cacheops/lua/fast_invalidate.lua
@@ -7,7 +7,7 @@ local obj = cjson.decode(ARGV[3])
 local conj_cache_key = function (db_table, scheme, obj)
     local parts = {}
     for field in string.gmatch(scheme, "[^,]+") do
-        table.insert(parts, field .. '=' .. tostring(obj[field]):lower())
+        table.insert(parts, field .. '=' .. tostring(obj[field]):upper())
     end
 
     return 'conj:' .. db_table .. ':' .. table.concat(parts, '&')

--- a/cacheops/lua/invalidate.lua
+++ b/cacheops/lua/invalidate.lua
@@ -6,7 +6,7 @@ local obj = cjson.decode(ARGV[2])
 local conj_cache_key = function (db_table, scheme, obj)
     local parts = {}
     for field in string.gmatch(scheme, "[^,]+") do
-        table.insert(parts, field .. '=' .. tostring(obj[field]):lower())
+        table.insert(parts, field .. '=' .. tostring(obj[field]):upper())
     end
 
     return 'conj:' .. db_table .. ':' .. table.concat(parts, '&')

--- a/cacheops/lua/invalidate.lua
+++ b/cacheops/lua/invalidate.lua
@@ -6,7 +6,7 @@ local obj = cjson.decode(ARGV[2])
 local conj_cache_key = function (db_table, scheme, obj)
     local parts = {}
     for field in string.gmatch(scheme, "[^,]+") do
-        table.insert(parts, field .. '=' .. tostring(obj[field]))
+        table.insert(parts, field .. '=' .. tostring(obj[field]):lower())
     end
 
     return 'conj:' .. db_table .. ':' .. table.concat(parts, '&')

--- a/cacheops/tree.py
+++ b/cacheops/tree.py
@@ -70,7 +70,7 @@ def dnfs(qs):
             alias = where.lhs.alias
             if isinstance(where, Exact):
                 return [[(alias, attname, where.rhs, True)]]
-            elif isinstance(where, IExact) and isinstance(where.rhs, (str, unicode)):
+            elif isinstance(where, IExact) and isinstance(where.rhs, basestring):
                 return [[(alias, attname, where.rhs.lower(), True)]]
             elif isinstance(where, IsNull):
                 return [[(alias, attname, None, where.rhs)]]

--- a/cacheops/tree.py
+++ b/cacheops/tree.py
@@ -30,9 +30,6 @@ except ImportError:
 from .utils import NOT_SERIALIZED_FIELDS
 
 
-LONG_DISJUNCTION = 8
-
-
 def dnfs(qs):
     """
     Converts query condition tree into a DNF of eq conds.
@@ -73,7 +70,7 @@ def dnfs(qs):
                 return [[(where.lhs.alias, attname, where.rhs, True)]]
             elif isinstance(where, IsNull):
                 return [[(where.lhs.alias, attname, None, where.rhs)]]
-            elif isinstance(where, In) and len(where.rhs) < LONG_DISJUNCTION:
+            elif isinstance(where, In) and len(where.rhs) < settings.CACHEOPS_LONG_DISJUNCTION:
                 return [[(where.lhs.alias, attname, v, True)] for v in where.rhs]
             else:
                 return SOME_TREE

--- a/cacheops/tree.py
+++ b/cacheops/tree.py
@@ -71,7 +71,7 @@ def dnfs(qs):
             if isinstance(where, Exact):
                 return [[(alias, attname, where.rhs, True)]]
             elif isinstance(where, IExact) and isinstance(where.rhs, basestring):
-                return [[(alias, attname, where.rhs.lower(), True)]]
+                return [[(alias, attname, where.rhs.upper(), True)]]
             elif isinstance(where, IsNull):
                 return [[(alias, attname, None, where.rhs)]]
             elif isinstance(where, In) and len(where.rhs) < settings.CACHEOPS_LONG_DISJUNCTION:

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -14,11 +14,7 @@ from .conf import model_profile
 
 # NOTE: we don't serialize this fields since their values could be very long
 #       and one should not filter by their equality anyway.
-NOT_SERIALIZED_FIELDS = (
-    models.FileField,
-    models.TextField, # One should not filter by long text equality
-    models.BinaryField,
-)
+NOT_SERIALIZED_FIELDS = models.FileField, models.BinaryField
 
 
 @memoize


### PR DESCRIPTION
cacheops stores sets of ORM resultset cache keys under "conj keys" made from the queries' filters, so that when a record that matches those filters is saved it can delete the caches that (it thinks) should have included that record.

But it doesn't include all the filters in the query – it skips `TextField`s (because in non-PostgreSQL DBs they aren't used for short text) and case-insensitive filters (because most users aren't upper-casing all searches), and any `IN` filter with more than eight items.

We use all those, so when a record is saved we are invalidating a lot more cached resultsets than we have to. **These changes include all those missing filters in the conj keys**, which should reduce the work done by invalidations and leave more valid resultsets in the cache.