### PR TITLE
PDT-925 Make the base Redis client class a setting and default to StrictRedis

### DIFF
--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -18,6 +18,7 @@ class Defaults(namespace):
     CACHEOPS = {}
     CACHEOPS_PREFIX = lambda query: ''
     CACHEOPS_LRU = False
+    CACHEOPS_CLIENT_CLASS = None
     CACHEOPS_DEGRADE_ON_FAILURE = False
     CACHEOPS_SENTINEL = {}
 

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 import six
 
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.module_loading import import_string
 
 from funcy import decorator, identity, memoize, LazyObject
 import redis
@@ -26,9 +27,13 @@ else:
 
 LOCK_TIMEOUT = 60
 
+client_class = redis.StrictRedis
+if settings.CACHEOPS_CLIENT_CLASS:
+    client_class = import_string(settings.CACHEOPS_CLIENT_CLASS)
 
-class CacheopsRedis(redis.StrictRedis):
-    get = handle_connection_failure(redis.StrictRedis.get)
+
+class CacheopsRedis(client_class):
+    get = handle_connection_failure(client_class.get)
 
     @contextmanager
     def getting(self, key, lock=False):

--- a/cacheops/redis.py
+++ b/cacheops/redis.py
@@ -27,13 +27,9 @@ else:
 
 LOCK_TIMEOUT = 60
 
-client_class = redis.StrictRedis
-if settings.CACHEOPS_CLIENT_CLASS:
-    client_class = import_string(settings.CACHEOPS_CLIENT_CLASS)
 
-
-class CacheopsRedis(client_class):
-    get = handle_connection_failure(client_class.get)
+class CacheopsRedis(redis.StrictRedis):
+    get = handle_connection_failure(redis.StrictRedis.get)
 
     @contextmanager
     def getting(self, key, lock=False):
@@ -89,6 +85,10 @@ def redis_client():
     if settings.CACHEOPS_REDIS and settings.CACHEOPS_SENTINEL:
         raise ImproperlyConfigured("CACHEOPS_REDIS and CACHEOPS_SENTINEL are mutually exclusive")
 
+    client_class = CacheopsRedis
+    if settings.CACHEOPS_CLIENT_CLASS:
+        client_class = import_string(settings.CACHEOPS_CLIENT_CLASS)
+
     if settings.CACHEOPS_SENTINEL:
         if not {'locations', 'service_name'} <= set(settings.CACHEOPS_SENTINEL):
             raise ImproperlyConfigured("Specify locations and service_name for CACHEOPS_SENTINEL")
@@ -96,16 +96,16 @@ def redis_client():
         sentinel = Sentinel(settings.CACHEOPS_SENTINEL['locations'])
         return sentinel.master_for(
             settings.CACHEOPS_SENTINEL['service_name'],
-            redis_class=CacheopsRedis,
+            redis_class=client_class,
             db=settings.CACHEOPS_SENTINEL.get('db', 0),
             socket_timeout=settings.CACHEOPS_SENTINEL.get('socket_timeout')
         )
 
     # Allow client connection settings to be specified by a URL.
     if isinstance(settings.CACHEOPS_REDIS, six.string_types):
-        return CacheopsRedis.from_url(settings.CACHEOPS_REDIS)
+        return client_class.from_url(settings.CACHEOPS_REDIS)
     else:
-        return CacheopsRedis(**settings.CACHEOPS_REDIS)
+        return client_class(**settings.CACHEOPS_REDIS)
 
 
 ### Lua script loader


### PR DESCRIPTION
### Jira URL
https://thetower.atlassian.net/browse/PDT-925

### Description
We've been maintaining this fork of https://github.com/Suor/django-cacheops for a long time, and it had diverged enough to make rebasing our fork on new upstream releases forbidding. Most of our changes were to the Redis client subclass. **This changes cacheops to accept the Redis client base class as a setting,** so we can maintain those features in Rover's repo instead. It should be easy to rebase this on new releases of cacheops going forward.

### Dependencies in Other Repo
Unless @suor merges https://github.com/Suor/django-cacheops/pull/282 into upstream cacheops real soon, we have to merge this into our fork before we can merge https://github.com/HearstCorp/rover/pull/1064

Once this is merged into our fork's `new-master` branch, we'll have to update Rover's requirements.txt to point to a new release tag.

### QA Instructions
Test https://github.com/HearstCorp/rover/pull/1064