### PR TITLE
PDT-1022 Use UNLINK if Redis version >= 4.0

### DIFF
--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -62,7 +62,11 @@ def invalidate_model(model, using=DEFAULT_DB_ALIAS):
     conjs_keys = redis_client.keys('%sconj:%s:*' % (prefix, model._meta.db_table))
     if conjs_keys:
         cache_keys = redis_client.sunion(conjs_keys)
-        redis_client.delete(*(list(cache_keys) + conjs_keys))
+        keys = list(cache_keys) + conjs_keys
+        if redis_can_unlink():
+            redis_client.execute_command('UNLINK', *keys)
+        else:
+            redis_client.delete(*keys)
     cache_invalidated.send(sender=model, obj_dict=None)
 
 

--- a/cacheops/lua/invalidate.lua
+++ b/cacheops/lua/invalidate.lua
@@ -1,6 +1,7 @@
 local prefix = KEYS[1]
 local db_table = ARGV[1]
 local obj = cjson.decode(ARGV[2])
+local conj_del_fn = ARGV[3]
 
 
 -- Utility functions
@@ -34,7 +35,7 @@ if next(conj_keys) ~= nil then
     local cache_keys = redis.call('sunion', unpack(conj_keys))
     -- we delete cache keys since they are invalid
     -- and conj keys as they will refer only deleted keys
-    redis.call('del', unpack(conj_keys))
+    redis.call(conj_del_fn, unpack(conj_keys))
     if next(cache_keys) ~= nil then
         -- NOTE: can't just do redis.call('del', unpack(...)) cause there is limit on number
         --       of return values in lua.

--- a/cacheops/lua/invalidate.lua
+++ b/cacheops/lua/invalidate.lua
@@ -1,8 +1,11 @@
 local prefix = KEYS[1]
 local db_table = ARGV[1]
 local obj = cjson.decode(ARGV[2])
-local conj_del_fn = ARGV[3]
-
+local conj_del_fn = 'unlink'
+-- If Redis version < 4.0 we can't use UNLINK
+-- TOSTRIP
+conj_del_fn = 'del'
+-- /TOSTRIP
 
 -- Utility functions
 local conj_cache_key = function (db_table, scheme, obj)


### PR DESCRIPTION
AWS ElastiCache now supports Redis 4.0, which offers asynchronous garbage collection of deleted and expired keys and their values. We believe that deletion of large conjunction set values stored by cacheops is the cause of repeated severe spikes in Redis latency that block all Rover reads.

**This change updates django-cacheops to call `UNLINK` instead of `DEL` if the Redis version is at least 4.0.** This will let us start regression and performance testing.