### PR TITLE
PDT-1291 Make cacheops conj exclusion rules into Django settings

### DIFF
--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -23,6 +23,7 @@ class Defaults(namespace):
     CACHEOPS_DEGRADE_ON_FAILURE = False
     CACHEOPS_SENTINEL = {}
     CACHEOPS_NOT_SERIALIZED_FIELDS = models.FileField, models.TextField, models.BinaryField
+    CACHEOPS_LONG_DISJUNCTION = 8
 
     FILE_CACHE_DIR = '/tmp/cacheops_file_cache'
     FILE_CACHE_TIMEOUT = 60*60*24*30

--- a/cacheops/conf.py
+++ b/cacheops/conf.py
@@ -5,6 +5,7 @@ from funcy import memoize, merge, namespace
 from django.conf import settings as base_settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.signals import setting_changed
+from django.db import models
 from django.utils.module_loading import import_string
 
 
@@ -21,6 +22,7 @@ class Defaults(namespace):
     CACHEOPS_CLIENT_CLASS = None
     CACHEOPS_DEGRADE_ON_FAILURE = False
     CACHEOPS_SENTINEL = {}
+    CACHEOPS_NOT_SERIALIZED_FIELDS = models.FileField, models.TextField, models.BinaryField
 
     FILE_CACHE_DIR = '/tmp/cacheops_file_cache'
     FILE_CACHE_TIMEOUT = 60*60*24*30

--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -7,7 +7,6 @@ from django.db.models.expressions import F, Expression
 from distutils.version import StrictVersion
 
 from .conf import settings
-from .utils import NOT_SERIALIZED_FIELDS
 from .sharding import get_prefix
 from .redis import redis_client, handle_connection_failure, load_script
 from .signals import cache_invalidated
@@ -103,7 +102,7 @@ no_invalidation = _no_invalidation()
 @memoize
 def serializable_fields(model):
     return tuple(f for f in model._meta.fields
-                   if not isinstance(f, NOT_SERIALIZED_FIELDS))
+                   if not isinstance(f, settings.CACHEOPS_NOT_SERIALIZED_FIELDS))
 
 @post_processing(dict)
 def get_obj_dict(model, obj):

--- a/cacheops/tree.py
+++ b/cacheops/tree.py
@@ -27,7 +27,7 @@ except ImportError:
     class RawSQL(object):
         pass
 
-from .utils import NOT_SERIALIZED_FIELDS
+from .conf import settings
 
 
 LONG_DISJUNCTION = 8
@@ -65,7 +65,7 @@ def dnfs(qs):
             if isinstance(where.rhs, (QuerySet, Query, Subquery, RawSQL)):
                 return SOME_TREE
             # Skip conditions on non-serialized fields
-            if isinstance(where.lhs.target, NOT_SERIALIZED_FIELDS):
+            if isinstance(where.lhs.target, settings.CACHEOPS_NOT_SERIALIZED_FIELDS):
                 return SOME_TREE
 
             attname = where.lhs.target.attname

--- a/cacheops/tree.py
+++ b/cacheops/tree.py
@@ -30,9 +30,6 @@ except ImportError:
 from .conf import settings
 
 
-LONG_DISJUNCTION = 8
-
-
 def dnfs(qs):
     """
     Converts query condition tree into a DNF of eq conds.
@@ -73,7 +70,7 @@ def dnfs(qs):
                 return [[(where.lhs.alias, attname, where.rhs, True)]]
             elif isinstance(where, IsNull):
                 return [[(where.lhs.alias, attname, None, where.rhs)]]
-            elif isinstance(where, In) and len(where.rhs) < LONG_DISJUNCTION:
+            elif isinstance(where, In) and len(where.rhs) < settings.CACHEOPS_LONG_DISJUNCTION:
                 return [[(where.lhs.alias, attname, v, True)] for v in where.rhs]
             else:
                 return SOME_TREE

--- a/cacheops/utils.py
+++ b/cacheops/utils.py
@@ -12,15 +12,6 @@ from django.http import HttpRequest
 from .conf import model_profile
 
 
-# NOTE: we don't serialize this fields since their values could be very long
-#       and one should not filter by their equality anyway.
-NOT_SERIALIZED_FIELDS = (
-    models.FileField,
-    models.TextField, # One should not filter by long text equality
-    models.BinaryField,
-)
-
-
 def get_concrete_model(model):
     return next(b for b in model.__mro__ if issubclass(b, models.Model) and not b._meta.abstract)
 


### PR DESCRIPTION
Cacheops makes "conj keys" to track the cached resultsets that should be invalidated when a resource is changed. Those keys are supposed to include all the fields in the queries that got those resultsets, but Suor felt that `TextField`s would be too large, and that `in` lists with more than 8 values would be too large, so cacheops leaves those out.

But we use `TextField`s for all text columns, and many of our queries do `in` of a large list of IDs. As a result, most cached resultset get added to generic conj keys. 

This is exacerbating the invalidation-spike issue, because those conj sets get way more keys they should – at our site, some get millions! – and when they are finally invalidated Redis blocks while deleting them all, which stops our application dead.

**This change makes those conj exclusion rules into Django settings**.