### PR TITLE
PDT-1396 Try encoding='latin1' if UnicodeDecodeError on pickle.loads()

### DIFF
--- a/cacheops/simple.py
+++ b/cacheops/simple.py
@@ -86,7 +86,10 @@ class RedisCache(BaseCache):
         data = self.conn.get(cache_key)
         if data is None:
             raise CacheMiss
-        return pickle.loads(data)
+        try:
+            return pickle.loads(data)
+        except UnicodeDecodeError:
+            return pickle.loads(data, encoding='latin1')
 
     @handle_connection_failure
     def set(self, cache_key, data, timeout=None):


### PR DESCRIPTION
### Jira ticket
https://thetower.atlassian.net/browse/PDT-1396

### Description
In Python 2.7, `pickle` encodes some serialized objects as 'latin1'. But Python 3's `pickle` [defaults to decoding them as `ascii`](https://docs.python.org/3.7/library/pickle.html#pickle.load), so

> Using encoding='latin1' is required for unpickling NumPy arrays and instances of datetime, date and time pickled by Python 2.

### QA instructions
Merge and release this, then update the Python 3 branch of Rover to install it and verify that it can load objects cached by the Python 2.7 branch.